### PR TITLE
Add a community page listing all BE groups

### DIFF
--- a/app/views/pages/community.html.haml
+++ b/app/views/pages/community.html.haml
@@ -1,0 +1,11 @@
+%section.blog
+  .wrapper
+    .article
+      %h1 Belgian Ruby Community
+        :markdown
+          * [BRUG](http://brug.be)
+          * [Rails Girls Brussels](http://railsgirls.com/brussels)
+          * [ruby_burgers.rb](http://www.meetup.com/ruby_burgers-rb/)
+          * [Arrrrcamp](http://2014.arrrrcamp.be/)
+          * [Belgian Ruby on Rails Professionals](https://www.linkedin.com/groups/Belgian-Ruby-on-Rails-Professionals-4059588/about)
+          * [IRC Chan #ruby.be](irc://chat.freenode.net:6697/ruby.be)


### PR DESCRIPTION
As discussed during last RG, here a simple page listing all BE groups. What do you think?
